### PR TITLE
Executor in Stopper plugin

### DIFF
--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -13,7 +13,7 @@ class Stopper(PoolDecorator):
     Decorator that sets demand to 0 if the partition has no pending jobs
 
     :param target: the pool
-    :param script: script that checks for pending jobs on the partition
+    :param script: path to script that checks for pending jobs
     :param interval: interval in seconds between execution of the script
 
     If there are pending jobs on the partition, the demand is not modified.

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -39,7 +39,7 @@ class Stopper(PoolDecorator):
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await proc.communicate()
-            self.n_pend_jobs = int(stdout.decode("ascii").strip())
+            self.n_pend_jobs = int(stdout.decode("ascii"))
             await asyncio.sleep(self.interval)
 
     def __init__(

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -10,7 +10,7 @@ from cobald.daemon import service
 @service(flavour=asyncio)
 class Stopper(PoolDecorator):
     """
-    Decorator that sets demand to 0 if the partition has no pending jobs
+    Decorator that sets demand to 0 if there are no pending jobs
 
     :param target: the pool
     :param script: path to script that checks for pending jobs

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -51,7 +51,6 @@ class Stopper(PoolDecorator):
         super().__init__(target)
         enforce(interval > 0, ValueError("interval must be positive"))
         enforce(script != "", ValueError("script must be specified"))
-        self._demand = target.demand
         self.interval = interval
         self.n_pend_jobs = 0
         self.script = script

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -1,6 +1,6 @@
 from cobald.interfaces import Pool, PoolDecorator
 
-from ..utility import enforce
+from cobald.utility import enforce
 
 import asyncio
 

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -28,15 +28,7 @@ class Stopper(PoolDecorator):
 
     @demand.setter
     def demand(self, value: float):
-        self._demand = self._condition_slurm(value)
-        self.target.demand = self._demand
-
-    def _condition_slurm(self, value):
-        """Return 0 if there are no pending jobs, otherwise pass `value`"""
-        if self.n_pend_jobs == 0:
-            return 0
-        else:
-            return value
+        self.target.demand = value if self.n_pend_jobs else 0
 
     async def run(self):
         """Retrieve the number of pending jobs"""

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -37,7 +37,7 @@ class Stopper(PoolDecorator):
     async def run(self):
         """Retrieve the number of pending jobs"""
         while True:
-            status = await self.executor.run_command(f". {self.script}")
+            status = await self.executor.run_command(f"{self.script}")
             self.n_pend_jobs = int(status.stdout)
             await asyncio.sleep(self.interval)
 

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -1,0 +1,65 @@
+from cobald.interfaces import Pool, PoolDecorator
+
+from ..utility import enforce
+
+import asyncio
+
+from cobald.daemon import service
+
+
+@service(flavour=asyncio)
+class Stopper(PoolDecorator):
+    """
+    Decorator that sets demand to 0 if the partition has no pending jobs
+
+    :param target: the pool
+    :param script: script that checks for pending jobs on the partition
+    :param interval: interval in seconds between execution of the script
+
+    If there are pending jobs on the partition, the demand is not modified.
+    The demand is set to 0 as long as no pending jobs are detected.
+
+    The default interval is 300 (5 minutes). The script has to be specified.
+    """
+
+    @property
+    def demand(self) -> float:
+        return self._demand
+
+    @demand.setter
+    def demand(self, value: float):
+        self._demand = self._condition_slurm(value)
+        self.target.demand = self._demand
+
+    def _condition_slurm(self, value):
+        """Return 0 if there are no pending jobs, otherwise pass `value`"""
+        if self.n_pend_jobs == 0:
+            return 0
+        else:
+            return value
+
+    async def run(self):
+        """Retrieve the number of pending jobs"""
+        while True:
+            proc = await asyncio.create_subprocess_shell(
+                f". {self.script}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await proc.communicate()
+            self.n_pend_jobs = int(stdout.decode("ascii").strip())
+            await asyncio.sleep(self.interval)
+
+    def __init__(
+        self,
+        target: Pool,
+        script: str = "",
+        interval: int = 300,
+    ):
+        super().__init__(target)
+        enforce(interval > 0, ValueError("interval must be positive"))
+        enforce(script != "", ValueError("script must be specified"))
+        self._demand = target.demand
+        self.interval = interval
+        self.n_pend_jobs = 0
+        self.script = script

--- a/cobald_hep_plugins/stopper.py
+++ b/cobald_hep_plugins/stopper.py
@@ -24,7 +24,7 @@ class Stopper(PoolDecorator):
 
     @property
     def demand(self) -> float:
-        return self._demand
+        return self.target.demand
 
     @demand.setter
     def demand(self, value: float):

--- a/docs/plugins/stopper.rst
+++ b/docs/plugins/stopper.rst
@@ -7,11 +7,13 @@ Start/Stop Plugin
 
 This plugin sets the demand to 0 and keeps it at 0 as long as there are no pending jobs on the monitored partition. If there are pending jobs on the partition, the demand is not modified by the plugin.
 
-The plugin is configured via the COBalD configuration file. The available parameters are ``script`` and ``interval``.
+The plugin is configured via the COBalD configuration file. The available parameters are ``script``, ``interval``, and ``executor``.
 
 ``script`` is a mandatory parameter and defines the location of the script that checks for pending jobs on the monitored partition. The script should contain the command of the respective batch system that returns the number of pending jobs. An example for the Slurm batch system is: ``squeue -p name_of_partition -t pending -h | wc -l``.
 
 ``interval`` defines the time in seconds between executions of the script. The default value is ``300``.
+
+``executor`` defines how the script is executed, e.g. in the shell or via an SSH connection. The default is the execution in the shell via ShellExecutor.
 
 An example configuration of the plugin in a COBalD configuration file using the YAML interface is:
 

--- a/docs/plugins/stopper.rst
+++ b/docs/plugins/stopper.rst
@@ -5,12 +5,15 @@ Start/Stop Plugin
 .. py:module:: cobald_hep_plugins.stopper
     :synopsis: Stops the booting of new drones if there are no pending jobs on the monitored partition
 
-This plugin sets the demand to 0 and keeps it at 0 as long as there are no pending jobs on the monitored partition. If there are pending jobs on the partition, the demand is not modified.
-The plugin is configured via the COBALD config file. The available parameters are ``script`` and ``interval``.
-``script`` is a mandatory parameter and defines the location of the script that checks for pending jobs on the monitored partition. The script should contain the command of the respective batch system that returns just the number of the pending jobs. A example for the slurm batch system is: ``squeue -p name_of_partition -t pending -h | wc -l``.
+This plugin sets the demand to 0 and keeps it at 0 as long as there are no pending jobs on the monitored partition. If there are pending jobs on the partition, the demand is not modified by the plugin.
+
+The plugin is configured via the COBalD configuration file. The available parameters are ``script`` and ``interval``.
+
+``script`` is a mandatory parameter and defines the location of the script that checks for pending jobs on the monitored partition. The script should contain the command of the respective batch system that returns the number of pending jobs. An example for the Slurm batch system is: ``squeue -p name_of_partition -t pending -h | wc -l``.
+
 ``interval`` defines the time in seconds between executions of the script. The default value is ``300``.
 
-The configuration in the COBALD config:
+An example configuration of the plugin in a COBalD configuration file using the YAML interface is:
 
 .. code:: yaml
 	  

--- a/docs/plugins/stopper.rst
+++ b/docs/plugins/stopper.rst
@@ -3,7 +3,7 @@ Start/Stop Plugin
 #################
 
 .. py:module:: cobald_hep_plugins.stopper
-    :synopsis: Stops the booting of new drones if there are no pending jobs on the monitored partition
+    :synopsis: Stops the booting of new drones if there are no pending jobs
 
 This plugin sets the demand to 0 and keeps it at 0 as long as there are no pending jobs on the monitored partition. If there are pending jobs on the partition, the demand is not modified by the plugin.
 

--- a/docs/plugins/stopper.rst
+++ b/docs/plugins/stopper.rst
@@ -1,0 +1,19 @@
+#################
+Start/Stop Plugin
+#################
+
+.. py:module:: cobald_hep_plugins.stopper
+    :synopsis: Stops the booting of new drones if there are no pending jobs on the monitored partition
+
+This plugin sets the demand to 0 and keeps it at 0 as long as there are no pending jobs on the monitored partition. If there are pending jobs on the partition, the demand is not modified.
+The plugin is configured via the COBALD config file. The available parameters are ``script`` and ``interval``.
+``script`` is a mandatory parameter and defines the location of the script that checks for pending jobs on the monitored partition. The script should contain the command of the respective batch system that returns just the number of the pending jobs. A example for the slurm batch system is: ``squeue -p name_of_partition -t pending -h | wc -l``.
+``interval`` defines the time in seconds between executions of the script. The default value is ``300``.
+
+The configuration in the COBALD config:
+
+.. code:: yaml
+	  
+    - !Stopper
+    script: '/path/to/script.sh'
+    interval: 60

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -32,4 +32,5 @@ class TestStopper(object):
         stopper.n_pend_jobs = 0
 
         for value in (0, 1, 5, 10, 1000):
-            assert stopper._condition_slurm(value) == 0
+            stopper.demand = value
+            assert stopper.demand == 0

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ..mock.pool import FullMockPool
+
+from cobald.decorator.stopper import Stopper
+
+
+class TestStopper(object):
+    def test_init_enforcement(self):
+        pool = FullMockPool()
+        with pytest.raises(ValueError):
+            Stopper(pool, script="test.sh", interval=-10)
+        with pytest.raises(ValueError):
+            Stopper(pool, script="")
+        with pytest.raises(ValueError):
+            Stopper(pool)
+
+    def test_running(self):
+        pool = FullMockPool()
+        stopper = Stopper(pool, script="test.sh")
+
+        for pend_jobs in (2, 7, 150, 5000):
+            stopper.n_pend_jobs = pend_jobs
+            for value in (0, 1, 5, 10, 1000):
+                assert stopper._condition_slurm(value) == value
+
+    def test_idle(self):
+        pool = FullMockPool()
+        stopper = Stopper(pool, script="test.sh")
+
+        stopper.n_pend_jobs = 0
+
+        for value in (0, 1, 5, 10, 1000):
+            assert stopper._condition_slurm(value) == 0

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -22,8 +22,8 @@ class TestStopper(object):
         for pend_jobs in (2, 7, 150, 5000):
             stopper.n_pend_jobs = pend_jobs
             for value in (0, 1, 5, 10, 1000):
-               stopper.demand = value
-               assert stopper.demand == value
+                stopper.demand = value
+                assert stopper.demand == value
 
     def test_idle(self):
         pool = MockPool()

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -22,7 +22,8 @@ class TestStopper(object):
         for pend_jobs in (2, 7, 150, 5000):
             stopper.n_pend_jobs = pend_jobs
             for value in (0, 1, 5, 10, 1000):
-                assert stopper._condition_slurm(value) == value
+               stopper.demand = value
+               assert stopper.demand == value
 
     def test_idle(self):
         pool = MockPool()

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -1,13 +1,13 @@
 import pytest
 
-from ..mock.pool import FullMockPool
+from .utility import MockPool
 
-from cobald.decorator.stopper import Stopper
+from cobald_hep_plugins.stopper import Stopper
 
 
 class TestStopper(object):
     def test_init_enforcement(self):
-        pool = FullMockPool()
+        pool = MockPool()
         with pytest.raises(ValueError):
             Stopper(pool, script="test.sh", interval=-10)
         with pytest.raises(ValueError):
@@ -16,7 +16,7 @@ class TestStopper(object):
             Stopper(pool)
 
     def test_running(self):
-        pool = FullMockPool()
+        pool = MockPool()
         stopper = Stopper(pool, script="test.sh")
 
         for pend_jobs in (2, 7, 150, 5000):
@@ -25,7 +25,7 @@ class TestStopper(object):
                 assert stopper._condition_slurm(value) == value
 
     def test_idle(self):
-        pool = FullMockPool()
+        pool = MockPool()
         stopper = Stopper(pool, script="test.sh")
 
         stopper.n_pend_jobs = 0

--- a/tests/test_stopper.py
+++ b/tests/test_stopper.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 from cobald_hep_plugins.stopper import Stopper
 
 from .utility import MockPool, cobald_yaml_config, get_cobald_config_section
@@ -35,6 +34,7 @@ class TestStopper(object):
         for value in (0, 1, 5, 10, 1000):
             stopper.demand = value
             assert stopper.demand == 0
+
 
 def test_load_yaml_tag():
     """Test that the plugin can be loaded via a YAML !tag"""


### PR DESCRIPTION
We need to run the script that counts the pending jobs via SSH, therefore we need to use the `SSHExecutor`.
This pull request adds a new parameter to the Stopper plugin, `executor`, and uses the executor to run the script. The default is `ShellExecutor`, so the default behavior doesn't change.